### PR TITLE
Add gzip to dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ into ASCII art in real-time using ncurses.
 - Linux (for v4l2)
 - A camera (obviously)
 - gcc
+- gzip
 - ncurses library
 - tmux (optional but recommended)
 


### PR DESCRIPTION
Sorry, this slipped my mind the other day. gzip is required for compressing the manpage before it is copied to /usr/share/man/man1/.